### PR TITLE
Update installing.rst

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -83,7 +83,7 @@ can run ``cmqttd`` manually within the container (ie: skipping the start-up scri
 If you want to run the ``cmqttd`` daemon on the same device as the Home Assistant server with the
 MQTT broker add-on you can::
 
-    # docker run --device /dev/ttyUSB0 --network hassio \
+    # docker run -d --device /dev/ttyUSB0 --network hassio \
         -e "TZ=Australia/Adelaide" cmqttd cmqttd \
         -s /dev/ttyUSB0 -b 172.30.33.0 --broker-disable-tls
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -79,5 +79,17 @@ can run ``cmqttd`` manually within the container (ie: skipping the start-up scri
 
     When running without the start-up script, you must write ``cmqttd`` twice: first as the name of
     the image, and second as the name of the program inside the image to run.
+	
+If you want to run the ``cmqttd`` daemon on the same device as the Home Assistant server with the
+MQTT broker add-on you can::
+
+    # docker run --device /dev/ttyUSB0 --network hassio \
+        -e "TZ=Australia/Adelaide" cmqttd cmqttd \
+        -s /dev/ttyUSB0 -b 172.30.33.0 --broker-disable-tls
+
+.. note::
+
+    The IP address for the MQTT broker on the hassio docker network may be discovered with:
+        # docker network inspect hassio
 
 More information about options is available from :doc:`the cmqttd doc page <cmqttd>`.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -83,13 +83,14 @@ can run ``cmqttd`` manually within the container (ie: skipping the start-up scri
 If you want to run the ``cmqttd`` daemon on the same device as the Home Assistant server with the
 MQTT broker add-on you can::
 
-    # docker run -d --device /dev/ttyUSB0 --network hassio \
+    # docker run -dit --name cbus --restart=always \
+        --device /dev/ttyUSB0 --network hassio \
         -e "TZ=Australia/Adelaide" cmqttd cmqttd \
-        -s /dev/ttyUSB0 -b 172.30.33.0 --broker-disable-tls
+        -s /dev/ttyUSB0 -b core-mosquitto --broker-disable-tls
 
 .. note::
 
-    The IP address for the MQTT broker on the hassio docker network may be discovered with:
-        # docker network inspect hassio
+    The Hostname for the MQTT broker on the hassio docker network is typically ``core-mosquito``.
+    Confirm with: ``# docker inspect addon_core_mosquitto``
 
 More information about options is available from :doc:`the cmqttd doc page <cmqttd>`.


### PR DESCRIPTION
 --device /dev/ttyUSB0 is required to bind the serial port on the docker host device
--network hassio is the default docker bridge network for Home Assistant