### PR TITLE
Expanded to all lighting applications - backward compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ example.*
 home.*
 img
 .coverage
+*.cbz
+*.pem
+*.key
+auth
+certificates

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ auth
 certificates
 .vscode
 project.xml
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,11 @@ example.*
 home.*
 img
 .coverage
-*.cbz
-*.pem
-*.key
-auth
+cmqttd_config/*.cbz
+cmqttd_config/*.pem
+cmqttd_config/*.key¸
+cmqttd_config/*.xml
+cmqttd_config/auth
 certificates
 .vscode
 project.xml

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ img
 *.key
 auth
 certificates
+.vscode
+project.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN pip3 install 'parameterized' && \
 # cmqttd runner image
 FROM base as cmqttd
 COPY COPYING COPYING.LESSER Dockerfile README.md entrypoint-cmqttd.sh /
+RUN sed -i 's/\r$//' entrypoint-cmqttd.sh 
 COPY --from=builder /cbus/dist/cbus-0.2.generic.tar.gz /
 RUN tar zxf /cbus-0.2.generic.tar.gz && rm /cbus-0.2.generic.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,13 @@
 # $ docker build -t cmqttd .
 # $ docker run --device /dev/ttyUSB0 -e "SERIAL_PORT=/dev/ttyUSB0" \
 #     -e "MQTT_SERVER=192.2.0.1" -e "TZ=Australia/Adelaide" -it cmqttd
-FROM alpine:3.11 as base
+FROM alpine:edge as base
+# python 3.10 required, at date this file is created only available in alpine:edge
 
 # Install most Python deps here, because that way we don't need to include build tools in the
 # final image.
-RUN apk add --no-cache python3 py3-cffi py3-paho-mqtt py3-six tzdata && \
-    pip3 install 'pyserial==3.4' 'pyserial_asyncio==0.4'
+RUN apk add --no-cache python3 py-pip py3-cffi py3-paho-mqtt py3-six tzdata && \
+    pip3 install 'pyserial==3.5' 'pyserial_asyncio==0.6'
 
 # Runs tests and builds a distribution tarball
 FROM base as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY COPYING COPYING.LESSER Dockerfile README.md entrypoint-cmqttd.sh /
 RUN sed -i 's/\r$//' entrypoint-cmqttd.sh 
 COPY --from=builder /cbus/dist/cbus-0.2.generic.tar.gz /
 RUN tar zxf /cbus-0.2.generic.tar.gz && rm /cbus-0.2.generic.tar.gz
+COPY cmqttd_config/ /etc/cmqttd/ 
 
 # Runs cmqttd itself
 CMD /entrypoint-cmqttd.sh

--- a/cbus/common.py
+++ b/cbus/common.py
@@ -116,9 +116,27 @@ class Application(IntEnum):
     LIGHTING_5d = 0x5d
     LIGHTING_5e = 0x5e
     LIGHTING_LAST = LIGHTING_5f = 0x5f
+    HVACACTUATOR_73 = 0x73
+    HVACACTUATOR_74 = 0x74
+    HVAC = 0xCA
     CLOCK = 0xDF
+    TRIGGER = 0xCA
     ENABLE = 0xCB
     MASTER_APPLICATION = STATUS_REQUEST = 0xff
+
+    def isLighting(val):
+        if isinstance(val,Application):
+          val = int(val)
+        if isinstance(val,int):
+          return int(Application.LIGHTING_FIRST)<=val<=int(Application.LIGHTING_LAST)
+        return False
+
+    def isHvacActuator(val):
+        if isinstance(val,Application):
+          val = int(val)
+        if isinstance(val,int):
+          return int(Application.HVACACTUATOR_73)==val or int(Application.HVACACTUATOR_74)==val
+        return False
 
 
 class CAL(IntEnum):
@@ -429,3 +447,9 @@ def check_ga(group_addr: int) -> None:
         raise ValueError(
             'Group Address out of range ({}..{}), got {}'.format(
                 MIN_GROUP_ADDR, MAX_GROUP_ADDR, group_addr))
+
+
+def check_aa_lighting(app_addr: int | Application) -> None:
+     if not Application.isLighting(app_addr):
+        raise ValueError(
+            'Expected lighting application address, got {}'.format(app_addr))

--- a/cbus/common.py
+++ b/cbus/common.py
@@ -124,19 +124,6 @@ class Application(IntEnum):
     ENABLE = 0xCB
     MASTER_APPLICATION = STATUS_REQUEST = 0xff
 
-    def isLighting(val):
-        if isinstance(val,Application):
-          val = int(val)
-        if isinstance(val,int):
-          return int(Application.LIGHTING_FIRST)<=val<=int(Application.LIGHTING_LAST)
-        return False
-
-    def isHvacActuator(val):
-        if isinstance(val,Application):
-          val = int(val)
-        if isinstance(val,int):
-          return int(Application.HVACACTUATOR_73)==val or int(Application.HVACACTUATOR_74)==val
-        return False
 
 
 class CAL(IntEnum):
@@ -448,8 +435,3 @@ def check_ga(group_addr: int) -> None:
             'Group Address out of range ({}..{}), got {}'.format(
                 MIN_GROUP_ADDR, MAX_GROUP_ADDR, group_addr))
 
-
-def check_aa_lighting(app_addr: int | Application) -> None:
-     if not Application.isLighting(app_addr):
-        raise ValueError(
-            'Expected lighting application address, got {}'.format(app_addr))

--- a/cbus/daemon/cmqttd.py
+++ b/cbus/daemon/cmqttd.py
@@ -120,16 +120,13 @@ class CBusHandler(PCIProtocol):
             return
         self.mqtt_api.lighting_group_ramp(
             source_addr, group_addr, app_addr,duration, level)
-        #need to address application
 
     def on_lighting_group_on(self, source_addr, group_addr,app_addr):
-        #need to address application
         if not self.mqtt_api:
             return
         self.mqtt_api.lighting_group_on(source_addr, group_addr,app_addr)
 
     def on_lighting_group_off(self, source_addr, group_addr,app_addr):
-        #need to address application
         if not self.mqtt_api:
             return
         self.mqtt_api.lighting_group_off(source_addr, group_addr,app_addr)

--- a/cbus/daemon/cmqttd.py
+++ b/cbus/daemon/cmqttd.py
@@ -295,7 +295,7 @@ class MqttClient(mqtt.Client):
 
     
     def publish_binary_sensor(self, group_addr: int, app_addr: int | Application, state: Optional[bool]):
-        payload = "UNK" if state == None else ('ON' if state else 'OFF')
+        payload = 'ON' if state else 'OFF'
         return super().publish(
             bin_sensor_state_topic(group_addr,app_addr), payload, 1, True)
 

--- a/cbus/daemon/cmqttd.py
+++ b/cbus/daemon/cmqttd.py
@@ -22,6 +22,11 @@ import logging
 from typing import Any, BinaryIO, Dict, Optional, Text, TextIO
 
 import paho.mqtt.client as mqtt
+import sys
+
+if sys.platform == 'win32':
+    from asyncio import set_event_loop_policy, WindowsSelectorEventLoopPolicy
+    set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
 try:
     from serial_asyncio import create_serial_connection

--- a/cbus/protocol/application/clock.py
+++ b/cbus/protocol/application/clock.py
@@ -50,7 +50,7 @@ class ClockSAL(SAL, abc.ABC):
         return Application.CLOCK
 
     @staticmethod
-    def decode_sals(data: bytes) -> Sequence[ClockSAL]:
+    def decode_sals(data: bytes,_=None) -> Sequence[ClockSAL]:
         """
         Decodes a clock broadcast application packet and returns it's SAL(s).
 
@@ -251,7 +251,7 @@ class ClockApplication(BaseApplication):
         return {Application.CLOCK}
 
     @staticmethod
-    def decode_sals(data: bytes) -> Sequence[SAL]:
+    def decode_sals(data: bytes,_=None) -> Sequence[SAL]:
         """
         Decodes a clock and timekeeping application packet and returns its
         SAL(s).

--- a/cbus/protocol/application/enable.py
+++ b/cbus/protocol/application/enable.py
@@ -43,7 +43,7 @@ class EnableSAL(SAL):
         return Application.ENABLE
 
     @staticmethod
-    def decode_sals(data: bytes) -> List[EnableSAL]:
+    def decode_sals(data: bytes,_=None) -> List[EnableSAL]:
         """
         Decodes a enable control application packet and returns it's SAL(s).
 
@@ -150,7 +150,7 @@ class EnableApplication(BaseApplication):
         return {Application.ENABLE}
 
     @classmethod
-    def decode_sals(cls, data: bytes) -> List[EnableSAL]:
+    def decode_sals(cls, data: bytes, _ = None) -> List[EnableSAL]:
         """
         Decodes a enable broadcast application packet and returns its SAL(s).
         """

--- a/cbus/protocol/application/lighting.py
+++ b/cbus/protocol/application/lighting.py
@@ -49,23 +49,26 @@ class LightingSAL(SAL, abc.ABC):
     Base type for lighting application SALs.
     """
 
-    def __init__(self, group_address: int):
+    def __init__(self, group_address: int, application_address: Union[Application,int]):
         """
         This should not be called directly by your code!
 
         Use one of the subclasses of cbus.protocol.lighting.LightingSAL
         instead.
         """
+        #TODO: modify to avoid redundancy
+        if not Application.isLighting(application_address):
+            raise ValueError('Expected light Application address, got {}'.format(application_address))
         check_ga(group_address)
+        self.application_address = application_address
         self.group_address = group_address
 
     @property
     def application(self) -> Union[int, Application]:
-        # TODO: Support other application IDs
-        return Application.LIGHTING
+        return self.application_address 
 
     @staticmethod
-    def decode_sals(data: bytes) -> List[LightingSAL]:
+    def decode_sals(data: bytes, application: int | Application ) -> List[LightingSAL]:
         """
         Decodes a lighting application packet and returns it's SAL(s).
 
@@ -98,7 +101,7 @@ class LightingSAL(SAL, abc.ABC):
                 break
 
             sal, data = _SAL_HANDLERS[command_code].decode(
-                data, command_code, group_address)
+                data, command_code, group_address,application)
 
             if sal:
                 output.append(sal)
@@ -128,7 +131,7 @@ class LightingRampSAL(LightingSAL):
 
     """
 
-    def __init__(self, group_address: int, duration: int, level: int):
+    def __init__(self, group_address: int,application_address: Union[int,Application] , duration: int, level: int ):
         """
         Creates a new SAL Lighting Ramp message.
 
@@ -142,14 +145,14 @@ class LightingRampSAL(LightingSAL):
                       indicating full brightness.
         :type level: int
         """
-        super().__init__(group_address=group_address)
+        super().__init__(group_address,application_address )
 
         self.duration = duration
         self.level = level
 
     @staticmethod
     def decode(data: bytes, command_code: int,
-               group_address: int) -> Tuple[Optional[LightingSAL], bytes]:
+               group_address: int, application_address: int | Application) -> Tuple[Optional[LightingSAL], bytes]:
         """
         Do not call this method directly -- use LightingSAL.decode
         """
@@ -165,7 +168,7 @@ class LightingRampSAL(LightingSAL):
         data = data[1:]
 
         return LightingRampSAL(
-            group_address=group_address, duration=duration, level=level), data
+            group_address=group_address, application_address=application_address,duration=duration, level=level), data
 
     def encode(self) -> bytes:
         if self.level < 0 or self.level > 255:
@@ -192,11 +195,11 @@ class LightingOnSAL(LightingSAL):
 
     @staticmethod
     def decode(data: bytes, command_code: int,
-               group_address: int) -> Tuple[LightingOnSAL, bytes]:
+               group_address: int, application_address: int | Application) -> Tuple[LightingOnSAL, bytes]:
         """
         Do not call this method directly -- use LightingSAL.decode
         """
-        return LightingOnSAL(group_address), data
+        return LightingOnSAL(group_address,application_address), data
 
     def encode(self):
         return super().encode() + bytes([LightCommand.ON, self.group_address])
@@ -214,11 +217,11 @@ class LightingOffSAL(LightingSAL):
 
     @staticmethod
     def decode(data: bytes, command_code: int,
-               group_address: int) -> Tuple[LightingOffSAL, bytes]:
+               group_address: int, application_address: int | Application) -> Tuple[LightingOffSAL, bytes]:
         """
         Do not call this method directly -- use LightingSAL.decode
         """
-        return LightingOffSAL(group_address), data
+        return LightingOffSAL(group_address,application_address), data
 
     def encode(self):
         return super().encode() + bytes([LightCommand.OFF, self.group_address])
@@ -237,11 +240,11 @@ class LightingTerminateRampSAL(LightingSAL):
 
     @staticmethod
     def decode(data: bytes, command_code: int,
-               group_address: int) -> Tuple[LightingTerminateRampSAL, bytes]:
+               group_address: int, application_address: int | Application)  -> Tuple[LightingTerminateRampSAL, bytes]:
         """
         Do not call this method directly -- use LightingSAL.decode
         """
-        return LightingTerminateRampSAL(group_address), data
+        return LightingTerminateRampSAL(group_address,application_address), data
 
     def encode(self):
         return super().encode() + bytes([
@@ -276,8 +279,8 @@ class LightingApplication(BaseApplication):
     """
 
     @staticmethod
-    def decode_sals(data: bytes) -> List[SAL]:
-        return LightingSAL.decode_sals(data)
+    def decode_sals(data: bytes, application: int | Application ) -> List[SAL]:
+        return LightingSAL.decode_sals(data,application)
 
     @staticmethod
     def supported_applications() -> FrozenSet[int]:

--- a/cbus/protocol/application/lighting.py
+++ b/cbus/protocol/application/lighting.py
@@ -57,7 +57,7 @@ class LightingSAL(SAL, abc.ABC):
         instead.
         """
         #TODO: modify to avoid redundancy
-        if not Application.isLighting(application_address):
+        if not application_address in _SUPPORTED_APPLICATIONS:
             raise ValueError('Expected light Application address, got {}'.format(application_address))
         check_ga(group_address)
         self.application_address = application_address

--- a/cbus/protocol/application/sal.py
+++ b/cbus/protocol/application/sal.py
@@ -57,7 +57,7 @@ class BaseApplication(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def decode_sals(data: bytes) -> Sequence[SAL]:
+    def decode_sals(data: bytes,application: int| Application=None) -> Sequence[SAL]:
         """
         Decodes a SAL message
 

--- a/cbus/protocol/application/status_request.py
+++ b/cbus/protocol/application/status_request.py
@@ -36,7 +36,7 @@ class StatusRequestApplication(BaseApplication):
         return _SUPPORTED_APPLICATIONS
 
     @staticmethod
-    def decode_sals(data: bytes) -> Sequence[SAL]:
+    def decode_sals(data: bytes,_=None) -> Sequence[SAL]:
         return StatusRequestSAL.decode_sals(data)
 
 
@@ -47,7 +47,7 @@ class StatusRequestSAL(SAL):
     child_application: int
 
     @classmethod
-    def decode_sals(cls, data: bytes) -> Sequence[StatusRequestSAL]:
+    def decode_sals(cls, data: bytes,_=None) -> Sequence[StatusRequestSAL]:
         output = []
 
         while data:

--- a/cbus/protocol/application/temperature.py
+++ b/cbus/protocol/application/temperature.py
@@ -53,7 +53,7 @@ class TemperatureSAL(SAL, abc.ABC):
         return Application.TEMPERATURE
 
     @staticmethod
-    def decode_sals(data: bytes) -> Sequence[TemperatureSAL]:
+    def decode_sals(data: bytes, _ = None) -> Sequence[TemperatureSAL]:
         """
         Decodes a temperature broadcast application packet and returns its
         SAL(s).
@@ -169,7 +169,7 @@ class TemperatureApplication(BaseApplication):
         return {Application.TEMPERATURE}
 
     @staticmethod
-    def decode_sals(data: bytes) -> Sequence[TemperatureSAL]:
+    def decode_sals(data: bytes, _ = None) -> Sequence[TemperatureSAL]:
         """
         Decodes a temperature broadcast application packet and returns it's
         SAL(s).

--- a/cbus/protocol/buffered_protocol.py
+++ b/cbus/protocol/buffered_protocol.py
@@ -67,23 +67,27 @@ class BufferedProtocol(asyncio.Protocol, abc.ABC):
         :param data: new data to add to the buffer
         :return: None
         """
-        data_size = len(data)
-        if data_size > self._size_limit:
-            raise ValueError('Received data exceeds size limit '
+        try:
+            data_size = len(data)
+            if data_size > self._size_limit:
+                raise ValueError('Received data exceeds size limit '
                              '({} bytes)'.format(self._size_limit))
 
-        # Add the data to the buffer
-        with self._buf_lock:
-            if len(self._buf) + data_size > self._size_limit:
-                self._buf = bytearray()
-                raise ValueError(
-                    'Received data would make the buffer exceed the maximum '
-                    'limit, buffer dropped!')
+            # Add the data to the buffer
+            with self._buf_lock:
+                if len(self._buf) + data_size > self._size_limit:
+                    self._buf = bytearray()
+                    raise ValueError(
+                        'Received data would make the buffer exceed the maximum '
+                        'limit, buffer dropped!')
 
-            self._buf.extend(data)
+                self._buf.extend(data)
 
-        # Handle any messages that may be in the buffer.
-        self._process_buffer()
+            # Handle any messages that may be in the buffer.
+            self._process_buffer()
+        except:
+            # Clear buffer.
+            self._buf =  bytearray()
 
     def _process_buffer(self):
         with self._buf_lock:

--- a/cbus/protocol/pciprotocol.py
+++ b/cbus/protocol/pciprotocol.py
@@ -326,7 +326,7 @@ class PCIProtocol(CBusProtocol):
         return int2byte(o)
 
     def _send(self,
-              cmd: Union[BasePacket],
+              cmd: BasePacket,
               confirmation: bool = True,
               basic_mode: bool = False):
         """

--- a/cbus/protocol/pciprotocol.py
+++ b/cbus/protocol/pciprotocol.py
@@ -384,10 +384,17 @@ class PCIProtocol(CBusProtocol):
             self._send(ResetPacket())
 
         # serial user interface guide sect 10.2
-        # Set application address 1 to 38 (lighting)
-        # self._send('A3210038', encode=False, checksum=False)
+        # Set application address 1 to ALL applications
+        # self._send('A32100FF', encode=False, checksum=False)
         self._send(DeviceManagementPacket(
-            checksum=False, parameter=0x21, value=0x38),
+            checksum=False, parameter=0x21, value=0xFF),
+            basic_mode=True)
+        
+        # serial user interface guide sect 10.2
+        # Set application address 2 to USED applications
+        # self._send('A32200FF', encode=False, checksum=False)
+        self._send(DeviceManagementPacket(
+            checksum=False, parameter=0x22, value=0xFF),
             basic_mode=True)
 
         # Interface options #3

--- a/cbus/protocol/pm_packet.py
+++ b/cbus/protocol/pm_packet.py
@@ -107,7 +107,7 @@ class PointToMultipointPacket(BasePacket, Sequence[SAL]):
         # find an application handler
         handler = get_application(application)
         data = data[2:]
-        sals = handler.decode_sals(data)
+        sals = handler.decode_sals(data,application)
 
         return cls(
             checksum=checksum, priority_class=priority_class,

--- a/cbus/toolkit/cbz.py
+++ b/cbus/toolkit/cbz.py
@@ -219,7 +219,7 @@ class CBZ:
             zip_h = ZipFile(fh, 'r')
         except BadZipFile:
             # Try to load as XML instead.
-            xml_fh = fh
+            xml_fh = fh.name
 
         if zip_h:
             files = zip_h.namelist()

--- a/cbus/toolkit/periodic.py
+++ b/cbus/toolkit/periodic.py
@@ -1,0 +1,29 @@
+import asyncio
+import queue
+
+class Periodic:
+  """   
+  class that manages a queue of functions to be called while 
+  leaving a interval between two successsive calls 
+  """
+  queue = []
+
+  def __init__(self,period = 1):
+    self.queue = queue.Queue()
+    self.period = period
+    loop = asyncio.get_event_loop()
+    self.task = loop.create_task(self._work())
+    
+  async def _work(self):
+    while True:
+      try:
+        action = self.queue.get(block=False)
+        action()
+      except:
+        pass
+      finally:
+        await asyncio.sleep(self.period)
+
+  def enqueue(self,task):
+    #talks is a lambda or the name of a function with no argument
+      self.queue.put(task)

--- a/cmqttd_config/README.md
+++ b/cmqttd_config/README.md
@@ -1,0 +1,16 @@
+# This folder should contain optional cmqttd configuration files.
+
+## project.cbz (file)
+This file provides cbus group labels. Create a backup of the cbus project with the cbus setup tool, copy the back up file in this folder and rename it: project.cbz
+
+## auth (file)
+Username and password to use to connect to an MQTT broker, separated by a newline character.
+If this file is not present, then cmqttd will try to use the MQTT broker without authentication.
+
+## certificates (directory)
+A directory of CA certificates to trust when connecting with TLS.
+If this directory is not present, the default (Python) CA store will be used instead.
+
+## client.pem  client.key (files)
+Client certificate (pem) and private key (key) to use to connect to the MQTT broker.
+

--- a/entrypoint-cmqttd.sh
+++ b/entrypoint-cmqttd.sh
@@ -82,6 +82,13 @@ else
     echo "${CMQTTD_PROJECT_FILE} not found; using generated labels."
 fi
 
+echo ">${CMQTTD_CBUS_NETWORK}<"
+
+if [ -n "${CMQTTD_CBUS_NETWORK}" ]; then
+    echo "Loading C-Bus network ${CMQTTD_CBUS_NETWORK}"
+    CMQTTD_ARGS="${CMQTTD_ARGS} --cbus-network  ${CMQTTD_CBUS_NETWORK}"
+fi
+
 echo ""
 
 # Announce what we think local time is on start-up. This will be sent to the C-Bus network.

--- a/requirements-cmqttd.txt
+++ b/requirements-cmqttd.txt
@@ -1,4 +1,4 @@
 pyserial==3.4
-pyserial_asyncio (==0.4)
+pyserial_asyncio (==0.6)
 six
-paho-mqtt==1.5.0
+paho-mqtt==1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pyserial==3.4
-pyserial_asyncio==0.4
+pyserial==3.5
+pyserial_asyncio==0.6
 six
 
 # official protocol documentation downloading
@@ -9,7 +9,7 @@ requests
 pydot
 
 # required for cmqttd
-paho-mqtt==1.5.0
+paho-mqtt==1.6.1
 
 # required for cbz
 lxml

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ based_on_style = google
 
 [pytype]
 inputs = cbus
-version = 3.7
+version = 3.10
 exclude = cbus/toolkit/cbz.py

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@
 from setuptools import setup, find_packages
 
 deps = [
-	'pyserial (==3.4)',
-	'pyserial_asyncio (==0.4)',
+	'pyserial (==3.5)',
+	'pyserial_asyncio (==0.6)',
 	'lxml (>=2.3.2)',
 	'six',
 	'pydot',
-	'paho_mqtt (==1.5.0)'
+	'paho_mqtt (==1.6.1)'
 ]
 
 tests_require = [

--- a/tests/test_cmqttd.py
+++ b/tests/test_cmqttd.py
@@ -23,7 +23,7 @@ import io
 from typing import Optional, Text, cast
 import unittest
 
-from cbus.common import check_ga
+from cbus.common import Application, check_ga
 from cbus.daemon import cmqttd
 
 
@@ -59,22 +59,22 @@ class CmqttdUtilityTest(unittest.TestCase):
         bin_topic_len = len(bin_topic)
 
         # base topic path -> ga
-        self.assertEqual(ga, cmqttd.get_topic_group_address(light_topic))
+        self.assertEqual((ga,Application.LIGHTING), cmqttd.get_topic_group_address(light_topic))
 
         # Generating a set topic
-        set_topic = cmqttd.set_topic(ga)
+        set_topic = cmqttd.set_topic(ga,Application.LIGHTING)
         self.assertEqual(light_topic, set_topic[:light_topic_len])
-        self.assertEqual(ga, cmqttd.get_topic_group_address(set_topic))
+        self.assertEqual((ga,Application.LIGHTING), cmqttd.get_topic_group_address(set_topic))
 
         # Generating a state topic
-        state_topic = cmqttd.state_topic(ga)
+        state_topic = cmqttd.state_topic(ga,Application.LIGHTING)
         self.assertEqual(light_topic, state_topic[:light_topic_len])
-        self.assertEqual(ga, cmqttd.get_topic_group_address(state_topic))
+        self.assertEqual((ga,Application.LIGHTING), cmqttd.get_topic_group_address(state_topic))
 
         # Generating a conf topic
-        conf_topic = cmqttd.conf_topic(ga)
+        conf_topic = cmqttd.conf_topic(ga,Application.LIGHTING)
         self.assertEqual(light_topic, conf_topic[:light_topic_len])
-        self.assertEqual(ga, cmqttd.get_topic_group_address(conf_topic))
+        self.assertEqual((ga,Application.LIGHTING), cmqttd.get_topic_group_address(conf_topic))
 
         # Ensure all the topics are unique
         self.assertNotEqual(set_topic, state_topic)
@@ -83,10 +83,10 @@ class CmqttdUtilityTest(unittest.TestCase):
 
         # Binary sensors are read only, so get_topic_group_address doesn't
         # support them.
-        bin_state_topic = cmqttd.bin_sensor_state_topic(ga)
+        bin_state_topic = cmqttd.bin_sensor_state_topic(ga,Application.LIGHTING)
         self.assertTrue(bin_topic, bin_state_topic[:bin_topic_len])
 
-        bin_conf_topic = cmqttd.bin_sensor_conf_topic(ga)
+        bin_conf_topic = cmqttd.bin_sensor_conf_topic(ga,Application.LIGHTING)
         self.assertTrue(bin_topic, bin_conf_topic[:bin_topic_len])
 
         # Uniqueness check

--- a/tests/test_lighting.py
+++ b/tests/test_lighting.py
@@ -16,8 +16,10 @@
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import
+from email.mime import application
 
 import unittest
+from cbus.common import Application
 
 from cbus.protocol.pm_packet import PointToMultipointPacket
 from cbus.protocol.application.lighting import (
@@ -127,7 +129,7 @@ class InternalLightingTest(CBusTestCase):
     def test_lighting_encode_decode(self):
         """test of encode then decode"""
 
-        orig = PointToMultipointPacket(sals=LightingOnSAL(27))
+        orig = PointToMultipointPacket(sals=LightingOnSAL(27,Application.LIGHTING))
         orig.source_address = 5
 
         data = orig.encode_packet() + b'\r\n'
@@ -142,7 +144,7 @@ class InternalLightingTest(CBusTestCase):
     def test_lighting_encode_decode_client(self):
         """test of encode then decode, with packets from a client"""
 
-        orig = PointToMultipointPacket(sals=LightingOnSAL(27))
+        orig = PointToMultipointPacket(sals=LightingOnSAL(27,Application.LIGHTING))
 
         data = b'\\' + orig.encode_packet() + b'\r'
 
@@ -155,23 +157,23 @@ class InternalLightingTest(CBusTestCase):
     def test_invalid_ga(self):
         """test argument validation"""
         with self.assertRaises(ValueError):
-            PointToMultipointPacket(sals=LightingOnSAL(999))
+            PointToMultipointPacket(sals=LightingOnSAL(999,Application.LIGHTING))
         with self.assertRaises(ValueError):
-            PointToMultipointPacket(sals=LightingOffSAL(-1))
+            PointToMultipointPacket(sals=LightingOffSAL(-1,Application.LIGHTING))
 
     def test_slow_ramp(self):
         """test very slow ramps"""
         p1 = PointToMultipointPacket(
-            sals=LightingRampSAL(1, 18*60, 255)).encode_packet()
+            sals=LightingRampSAL(1,Application.LIGHTING, 18*60, 255)).encode_packet()
         p2 = PointToMultipointPacket(
-            sals=LightingRampSAL(1, 17*60, 255)).encode_packet()
+            sals=LightingRampSAL(1,Application.LIGHTING, 17*60, 255)).encode_packet()
         self.assertEqual(p1, p2)
 
     def test_brightness_bounds(self):
         with self.assertRaisesRegex(ValueError, r'Ramp level .+ bounds'):
-            LightingRampSAL(1, 10, -1).encode()
+            LightingRampSAL(1,Application.LIGHTING, 10, -1).encode()
         with self.assertRaisesRegex(ValueError, r'Ramp level .+ bounds'):
-            LightingRampSAL(1, 10, 256).encode()
+            LightingRampSAL(1,Application.LIGHTING, 10, 256).encode()
 
 
 class LightingRegressionTest(CBusTestCase):

--- a/tests/test_pm_packet.py
+++ b/tests/test_pm_packet.py
@@ -64,14 +64,14 @@ class InternalPointToMultipointTest(CBusTestCase):
         with self.assertRaisesRegex(
                 ValueError, r'SAL .+ of application ff, .+ has application 38'):
             PointToMultipointPacket(sals=[
-                LightingOffSAL(1),
+                LightingOffSAL(1,Application.LIGHTING),
                 StatusRequestSAL(level_request=True, group_address=1,
                                  child_application=Application.LIGHTING),
             ])
 
     def test_remove_sals(self):
         # create a packet
-        p = PointToMultipointPacket(sals=LightingOffSAL(1))
+        p = PointToMultipointPacket(sals=LightingOffSAL(1,Application.LIGHTING))
         self.assertEqual(1, len(p))
 
         p.clear_sal()
@@ -84,7 +84,7 @@ class InternalPointToMultipointTest(CBusTestCase):
 
         # Adding another lighting SAL should fail
         with self.assertRaisesRegex(ValueError, r'has application ff$'):
-            p.append_sal(LightingOffSAL(1))
+            p.append_sal(LightingOffSAL(1,Application.LIGHTING))
         self.assertEqual(1, len(p))
 
     def test_invalid_sal(self):


### PR DESCRIPTION
1. Improved Windows compatibility

    + Added command to Dockerfile to automatically remove any CRLF line termination from the entry point script. They are sometimes added by git when it runs on Windows, and they prevent the script from running when the file is copied back on a Linux image.

    + Added code in cmqttd.py triggered when the code is run directly on a Windows machine. It deals with an issue related to windows ports' behavior within the event loop that results in an error. The issue is documented here: [https://bugs.python.org/issue37373](url)

2. Added directory cmqttd_config/ to received project file and MQTT credential files. The content is copied on the image in directory etc/cmqttd/

3. Added `application ` argument to SAL class and all derived classes. It is necessary to enable LightingSAL classes to address multiple applications. The argument is ignored/optional for other SAL application classes.

4. Adapted daemon to process all lighting applications. 

5. Improved label extraction logic:
    + Added argument to entry point sh and to mqttd:main to allow selecting a specific cbus network when the project file contains more than one.
    + Corrects bug when reading XML project files
    + All lighting application labels are now extracted; only groups with labels are published.
    + Groups are added dynamically if a packet is received later and no label was available in the project file.
    + If no application is available in project or project file is no provided, the default lighting application is assumed.
    + If an application has no label defined at all, all lights are published at start with default labels. 
    + Topic strings and device naming is backward compatible. 

6. Upgraded version requirements for libraries. Python 3.10 is now required (due to the use of new typing syntax), thus forcing to pull alpine:edge docker image (Should be changed after the next alpine upgrade)

7. Updated test code by adding application parameter to function calls when necessary. Test cases have not been modified otherwise. 

8. Added processing of level status report. The daemon automatically requests a report on all lighting applications at startup